### PR TITLE
feat(courbe): comparer la même période sur une année précédente

### DIFF
--- a/webapp-next/components/charts/line/Header.tsx
+++ b/webapp-next/components/charts/line/Header.tsx
@@ -59,7 +59,6 @@ export function ChartLineHeader() {
   const getIntervalLabel = (value: DateInterval) =>
     dateIntervals.find(di => di.value === value)?.label ?? '';
 
-  // La stratification "par région" n'est proposée qu'en France entière.
   const isFranceEntiere =
     filters.region_departments.length === ALL_DEPARTMENTS.length;
 
@@ -86,8 +85,6 @@ export function ChartLineHeader() {
       : getDefaultField<Field>(selectedFiltersPile, isValidField, 'sex')
   );
 
-  // Si le critère courant n'est plus disponible (ex: région après sortie de
-  // France entière), on retombe sur "sexe".
   if (!isAggregated && !isValidField(aggregateField)) {
     setAggregateField('sex');
     setSaveAggregateX('sex');
@@ -96,7 +93,6 @@ export function ChartLineHeader() {
   const updateAggregation = () => {
     let aggregation: any = {};
 
-    // Pas de la vue courbe piloté par le dropdown "Granularité".
     const dateAgg = {
       aggregated_date: {
         date_histogram: {
@@ -106,9 +102,8 @@ export function ChartLineHeader() {
       }
     };
 
-    // Mode comparaison (exclusif de la stratification) : on stratifie par année
-    // afin de séparer la période courante et la même période de l'année comparée
-    // en deux courbes superposables (cf. Line.tsx, axe normalisé).
+    // Comparaison : stratifier par année pour superposer les deux périodes
+    // (cf. axe normalisé dans Line.tsx).
     if (filters.compare_year) {
       setAggregations({
         aggregated_parent: {
@@ -212,7 +207,6 @@ export function ChartLineHeader() {
 
   const isCompareActive = !!filters.compare_year;
 
-  // La comparaison n'est proposée que si la période tient sur une seule année.
   const periodStartYear = filters.start_date
     ? new Date(filters.start_date).getFullYear()
     : undefined;
@@ -222,8 +216,6 @@ export function ChartLineHeader() {
   const periodSingleYear =
     periodStartYear !== undefined && periodStartYear === periodEndYear;
 
-  // Années comparables : de l'année précédant la période jusqu'à la première
-  // date disponible.
   const compareYearOptions: number[] = [];
   if (periodSingleYear && periodStartYear !== undefined) {
     for (let y = periodStartYear - 1; y >= firstDate.getFullYear(); y--) {
@@ -254,7 +246,6 @@ export function ChartLineHeader() {
 
   const handleCompareChange = (year?: number) => {
     if (year) {
-      // On repasse en distribution globale (exclusif de la stratification).
       setIsAggregated(true);
       setSaveAggregateX(undefined);
     }

--- a/webapp-next/components/charts/line/Header.tsx
+++ b/webapp-next/components/charts/line/Header.tsx
@@ -44,6 +44,8 @@ export function ChartLineHeader() {
     setSaveAggregateX,
     selectedFiltersPile,
     filters,
+    setFilters,
+    firstDate,
     dateInterval,
     setDateInterval
   } = context;
@@ -103,6 +105,24 @@ export function ChartLineHeader() {
         }
       }
     };
+
+    // Mode comparaison (exclusif de la stratification) : on stratifie par année
+    // afin de séparer la période courante et la même période de l'année comparée
+    // en deux courbes superposables (cf. Line.tsx, axe normalisé).
+    if (filters.compare_year) {
+      setAggregations({
+        aggregated_parent: {
+          date_histogram: {
+            field: 'date',
+            calendar_interval: 'year'
+          },
+          aggs: {
+            ...dateAgg
+          }
+        }
+      });
+      return;
+    }
 
     if (isAggregated) {
       aggregation = dateAgg;
@@ -177,7 +197,7 @@ export function ChartLineHeader() {
 
   useEffect(() => {
     updateAggregation();
-  }, [isAggregated, aggregateField, dateInterval]);
+  }, [isAggregated, aggregateField, dateInterval, filters.compare_year]);
 
   useEffect(() => {
     if (!isAggregated) {
@@ -190,17 +210,55 @@ export function ChartLineHeader() {
     setSaveAggregateX(isAggregated ? undefined : aggregateField);
   }, [isAggregated]);
 
+  const isCompareActive = !!filters.compare_year;
+
+  // La comparaison n'est proposée que si la période tient sur une seule année.
+  const periodStartYear = filters.start_date
+    ? new Date(filters.start_date).getFullYear()
+    : undefined;
+  const periodEndYear = filters.end_date
+    ? new Date(filters.end_date).getFullYear()
+    : undefined;
+  const periodSingleYear =
+    periodStartYear !== undefined && periodStartYear === periodEndYear;
+
+  // Années comparables : de l'année précédant la période jusqu'à la première
+  // date disponible.
+  const compareYearOptions: number[] = [];
+  if (periodSingleYear && periodStartYear !== undefined) {
+    for (let y = periodStartYear - 1; y >= firstDate.getFullYear(); y--) {
+      compareYearOptions.push(y);
+    }
+  }
+
   const handleViewChange = (view: View) => {
     setView(view);
   };
 
+  const clearCompare = () => {
+    if (filters.compare_year)
+      setFilters({ ...filters, compare_year: undefined });
+  };
+
+  // Comparaison et stratification sont mutuellement exclusives.
   const handleAggregationChange = (aggregated: boolean) => {
+    clearCompare();
     setIsAggregated(aggregated);
   };
 
   const handleLegendChange = (field: Field) => {
+    clearCompare();
     setAggregateField(field);
     setSaveAggregateX(field);
+  };
+
+  const handleCompareChange = (year?: number) => {
+    if (year) {
+      // On repasse en distribution globale (exclusif de la stratification).
+      setIsAggregated(true);
+      setSaveAggregateX(undefined);
+    }
+    setFilters({ ...filters, compare_year: year });
   };
 
   return (
@@ -248,30 +306,34 @@ export function ChartLineHeader() {
           ))}
         </MenuList>
       </Menu>
-      <Menu>
-        <MenuButton
-          ml={4}
-          as={Button}
-          variant="light"
-          rightIcon={<ChevronDownIcon color="primary.200" w={5} h={5} />}
-        >
-          Courbe :{' '}
-          <Text as="b">
-            {isAggregated ? 'Distribution globale' : 'Distribution stratifiée'}
-          </Text>
-        </MenuButton>
-        <MenuList>
-          <MenuItem onClick={() => handleAggregationChange(true)}>
-            <Text as={isAggregated ? 'b' : 'span'}>Distribution globale</Text>
-          </MenuItem>
-          <MenuItem onClick={() => handleAggregationChange(false)}>
-            <Text as={!isAggregated ? 'b' : 'span'}>
-              Distribution stratifiée
+      {!isCompareActive && (
+        <Menu>
+          <MenuButton
+            ml={4}
+            as={Button}
+            variant="light"
+            rightIcon={<ChevronDownIcon color="primary.200" w={5} h={5} />}
+          >
+            Courbe :{' '}
+            <Text as="b">
+              {isAggregated
+                ? 'Distribution globale'
+                : 'Distribution stratifiée'}
             </Text>
-          </MenuItem>
-        </MenuList>
-      </Menu>
-      {!isAggregated && (
+          </MenuButton>
+          <MenuList>
+            <MenuItem onClick={() => handleAggregationChange(true)}>
+              <Text as={isAggregated ? 'b' : 'span'}>Distribution globale</Text>
+            </MenuItem>
+            <MenuItem onClick={() => handleAggregationChange(false)}>
+              <Text as={!isAggregated ? 'b' : 'span'}>
+                Distribution stratifiée
+              </Text>
+            </MenuItem>
+          </MenuList>
+        </Menu>
+      )}
+      {!isAggregated && !isCompareActive && (
         <Menu>
           <MenuButton
             ml={4}
@@ -295,6 +357,36 @@ export function ChartLineHeader() {
           </MenuList>
         </Menu>
       )}
+      {periodSingleYear &&
+        (compareYearOptions.length > 0 || isCompareActive) && (
+          <Menu>
+            <MenuButton
+              ml={4}
+              as={Button}
+              variant="light"
+              rightIcon={<ChevronDownIcon color="primary.200" w={5} h={5} />}
+            >
+              Comparaison :{' '}
+              <Text as="b">
+                {filters.compare_year
+                  ? `${periodStartYear} vs ${filters.compare_year}`
+                  : 'Aucune'}
+              </Text>
+            </MenuButton>
+            <MenuList>
+              <MenuItem onClick={() => handleCompareChange(undefined)}>
+                <Text as={!isCompareActive ? 'b' : 'span'}>Aucune</Text>
+              </MenuItem>
+              {compareYearOptions.map(y => (
+                <MenuItem key={y} onClick={() => handleCompareChange(y)}>
+                  <Text as={filters.compare_year === y ? 'b' : 'span'}>
+                    {`Comparer avec ${y}`}
+                  </Text>
+                </MenuItem>
+              ))}
+            </MenuList>
+          </Menu>
+        )}
     </Flex>
   );
 }

--- a/webapp-next/components/charts/line/Line.tsx
+++ b/webapp-next/components/charts/line/Line.tsx
@@ -118,7 +118,9 @@ export const ChartLine = (props: Props) => {
   // dates ABSOLUES distinctes. On les remappe sur un axe commun « mois de
   // l'année » (année de référence neutre) pour qu'elles se superposent, au lieu
   // d'un alignement par index qui décalait les courbes.
-  const isYearComparison = saveAggregateX === 'years';
+  // Axe normalisé (superposition par mois/semaine/jour) : stratification par
+  // année OU mode comparaison « même période, autre année ».
+  const isYearComparison = saveAggregateX === 'years' || !!filters.compare_year;
   let labels = xValues;
   let renderDatasets = displayDatasets.map(({ hits, ...rest }: any) => rest);
 

--- a/webapp-next/components/charts/line/Line.tsx
+++ b/webapp-next/components/charts/line/Line.tsx
@@ -44,7 +44,7 @@ export const ChartLine = (props: Props) => {
             return {
               label: capitalizeString(label),
               data: yValues,
-              // Conservé pour le remappage mois-de-l'année (comparaison années).
+              // Conservé pour le remappage sur l'axe normalisé (plus bas).
               hits: ds.hits,
               fill: true,
               borderWidth: 2,
@@ -92,7 +92,6 @@ export const ChartLine = (props: Props) => {
   const min = new Date(filters.start_date);
   const max = new Date(filters.end_date);
 
-  // L'année n'est affichée sur l'axe que si la période couvre plusieurs années.
   const multiYear = min.getFullYear() !== max.getFullYear();
 
   const datasetWithMostHits = datasets.reduce((prev, current) => {
@@ -114,24 +113,17 @@ export const ChartLine = (props: Props) => {
     );
   });
 
-  // Comparaison année-sur-année : les séries (2022, 2023…) ont des buckets de
-  // dates ABSOLUES distinctes. On les remappe sur un axe commun « mois de
-  // l'année » (année de référence neutre) pour qu'elles se superposent, au lieu
-  // d'un alignement par index qui décalait les courbes.
-  // Axe normalisé (superposition par mois/semaine/jour) : stratification par
-  // année OU mode comparaison « même période, autre année ».
+  // Séries d'années différentes = dates absolues distinctes ; on les remappe sur
+  // un axe commun (mois/semaine/jour, année neutre) pour qu'elles se superposent,
+  // au lieu d'un alignement par index qui décalait les courbes.
   const isYearComparison = saveAggregateX === 'years' || !!filters.compare_year;
   let labels = xValues;
   let renderDatasets = displayDatasets.map(({ hits, ...rest }: any) => rest);
 
   if (isYearComparison) {
     const REF_YEAR = 2000;
-    // Position sur l'axe + libellé d'un bucket, INDÉPENDAMMENT de l'année, selon
-    // la granularité :
-    //  - semaine : numéro de semaine ISO (une même semaine tombe sur des dates
-    //    calendaires différentes selon l'année → normaliser par date serait faux),
-    //  - jour    : jour/mois,
-    //  - mois    : index de mois.
+    // Clé indépendante de l'année. Semaine = n° ISO : normaliser par date serait
+    // faux, une même semaine tombe sur des dates différentes selon l'année.
     const bucketKeyLabel = (
       keyAsString: string
     ): { key: number; label: string } => {

--- a/webapp-next/components/charts/map/Map.tsx
+++ b/webapp-next/components/charts/map/Map.tsx
@@ -40,7 +40,6 @@ export default function MapIframe(props: Props) {
     null
   );
 
-  // Département survolé + position souris (viewport) pour l'infobulle.
   const [hovered, setHovered] = useState<{
     code: string;
     nom: string;
@@ -63,15 +62,14 @@ export default function MapIframe(props: Props) {
     };
   }, []);
 
-  // Mémoïsé : évite de reconstruire toute la carte des départements à chaque
-  // mouvement de souris (l'infobulle déclenche des re-renders fréquents).
+  // Mémoïsé : l'infobulle re-render à chaque mouvement de souris, sans ça la
+  // carte entière serait reconstruite.
   const { config } = useMemo(
     () => getMapProps(datasets, filters.region_departments, saveAggregateX),
     [datasets, filters.region_departments, saveAggregateX]
   );
   const statesByCode = config?.state_specific ?? {};
 
-  // Départements dans le périmètre courant (région sélectionnée / France entière).
   const scoped = useMemo(
     () => new Set(filters.region_departments),
     [filters.region_departments]
@@ -89,9 +87,8 @@ export default function MapIframe(props: Props) {
 
   const features: GeoFeature[] = geojson?.features ?? [];
 
-  // Départements métropolitains DANS le périmètre courant : France entière =
-  // tous, région sélectionnée = uniquement ceux de la région (la projection
-  // ci-dessous se recadre donc automatiquement sur la région).
+  // Filtré sur le périmètre : la projection ci-dessous se recadre donc
+  // automatiquement sur la région sélectionnée.
   const metroFeatures = useMemo(
     () =>
       features.filter(
@@ -102,8 +99,6 @@ export default function MapIframe(props: Props) {
     [features, scoped]
   );
 
-  // Encarts DROM : seulement ceux présents dans le périmètre (France entière
-  // ou région d'outre-mer). La carte principale reste métropolitaine.
   const dromFeatures = useMemo(
     () =>
       features.filter(
@@ -126,15 +121,12 @@ export default function MapIframe(props: Props) {
     return <Text>Chargement de la carte…</Text>;
   }
 
-  // Aucune donnée cartographiable (ni métropole ni DROM dans le périmètre).
   if (!metroProjection && dromFeatures.length === 0) {
     return <Text>Carte indisponible.</Text>;
   }
 
   const hasMetro = !!metroProjection;
   const hasDrom = dromFeatures.length > 0;
-  // Une seule zone affichée (région métropolitaine seule, ou région DROM
-  // seule) → on la centre horizontalement dans le container.
   const single = hasMetro !== hasDrom;
 
   return (

--- a/webapp-next/components/charts/map/MapLegends.tsx
+++ b/webapp-next/components/charts/map/MapLegends.tsx
@@ -1,8 +1,6 @@
 import { Box, Flex, Text } from '@chakra-ui/react';
 
 export function MapLegends() {
-  // Colorimétrie relative à la médiane des décès des départements affichés
-  // (cf. utils/map/props.ts).
   const legends = [
     {
       color: '#c9e7c8',

--- a/webapp-next/components/charts/map/MapTooltip.tsx
+++ b/webapp-next/components/charts/map/MapTooltip.tsx
@@ -6,18 +6,13 @@ import { Box, ListItem, Text, UnorderedList } from '@chakra-ui/react';
 type StateEntry = MapConfig['state_specific'][string];
 
 type Props = {
-  // Nom de repli (propriété GeoJSON) quand le département n'a pas de données
-  // dans le périmètre courant.
   fallbackName: string;
   state?: StateEntry;
-  // Position à l'écran (coordonnées viewport de la souris).
   x: number;
   y: number;
 };
 
 export function MapTooltip({ fallbackName, state, x, y }: Props) {
-  // La même description HTML alimente le mode global (total seul) et le mode
-  // stratifié (ventilation par valeur) — cf. getMapProps.
   const details = state ? extractDetailsValues(state.description) : [];
 
   return (

--- a/webapp-next/components/layouts/Menu.tsx
+++ b/webapp-next/components/layouts/Menu.tsx
@@ -184,11 +184,8 @@ export function Menu() {
                 label: 'Déconnexion',
                 icon: '/icons/log-out.svg',
                 onClick: () => {
-                  // L'endpoint efface le cookie dans tous les cas et déduit le
-                  // username depuis la key ; on ne dépend plus de
-                  // context.user.username (indisponible si la session a expiré).
-                  // `finally` : on retourne au login même si l'appel échoue, et
-                  // href='/' (pas reload) pour ne pas retomber sur /bo.
+                  // href='/' (pas reload) dans finally : retour au login même si
+                  // l'appel échoue, sans risque de retomber sur /bo.
                   triggerInvalidateApiKey({
                     username: context.user.username as string
                   })

--- a/webapp-next/components/layouts/Menu.tsx
+++ b/webapp-next/components/layouts/Menu.tsx
@@ -184,13 +184,19 @@ export function Menu() {
                 label: 'Déconnexion',
                 icon: '/icons/log-out.svg',
                 onClick: () => {
+                  // L'endpoint efface le cookie dans tous les cas et déduit le
+                  // username depuis la key ; on ne dépend plus de
+                  // context.user.username (indisponible si la session a expiré).
+                  // `finally` : on retourne au login même si l'appel échoue, et
+                  // href='/' (pas reload) pour ne pas retomber sur /bo.
                   triggerInvalidateApiKey({
                     username: context.user.username as string
-                  }).then(() => {
-                    window.location.reload();
-                  });
-                },
-                link: '/'
+                  })
+                    .catch(() => {})
+                    .finally(() => {
+                      window.location.href = '/';
+                    });
+                }
               }
             ]}
           />

--- a/webapp-next/components/layouts/MenuLinks.tsx
+++ b/webapp-next/components/layouts/MenuLinks.tsx
@@ -23,7 +23,15 @@ export const MenuLinks: React.FC<Props> = ({ links }) => {
           alignItems="left"
           mt={8}
           key={index}
-          onClick={link.onClick ? link.onClick : () => {}}
+          onClick={(e) => {
+            if (link.onClick) {
+              // Élément d'action (pas de vraie destination) : on empêche la
+              // navigation vers href="" qui rechargerait la page courante et
+              // court-circuiterait l'action (ex. déconnexion, ouverture modale).
+              if (!link.link) e.preventDefault();
+              link.onClick();
+            }
+          }}
         >
           {link.icon && (
             <Image src={link.icon} width={24} height={24} alt="icon" />

--- a/webapp-next/components/layouts/MenuLinks.tsx
+++ b/webapp-next/components/layouts/MenuLinks.tsx
@@ -25,9 +25,8 @@ export const MenuLinks: React.FC<Props> = ({ links }) => {
           key={index}
           onClick={(e) => {
             if (link.onClick) {
-              // Élément d'action (pas de vraie destination) : on empêche la
-              // navigation vers href="" qui rechargerait la page courante et
-              // court-circuiterait l'action (ex. déconnexion, ouverture modale).
+              // Sans destination réelle, href="" rechargerait la page et
+              // court-circuiterait l'action.
               if (!link.link) e.preventDefault();
               link.onClick();
             }

--- a/webapp-next/components/layouts/SessionExpiredCard.tsx
+++ b/webapp-next/components/layouts/SessionExpiredCard.tsx
@@ -2,14 +2,9 @@ import { Button, Flex, Text } from '@chakra-ui/react';
 import { useState } from 'react';
 
 type Props = {
-  // true = session expirée (401/403) ; false = autre erreur serveur.
   expired: boolean;
 };
 
-// Affiché à la place du dashboard quand les requêtes ES échouent. Auparavant un
-// échec (typiquement une API key expirée pendant la nuit) laissait la page en
-// spinner infini, sans aucune porte de sortie. Ce panneau donne une action
-// claire : effacer le cookie et revenir à l'écran de connexion.
 export function SessionExpiredCard({ expired }: Props) {
   const [isLoggingOut, setIsLoggingOut] = useState(false);
 

--- a/webapp-next/components/layouts/SessionExpiredCard.tsx
+++ b/webapp-next/components/layouts/SessionExpiredCard.tsx
@@ -1,0 +1,67 @@
+import { Button, Flex, Text } from '@chakra-ui/react';
+import { useState } from 'react';
+
+type Props = {
+  // true = session expirée (401/403) ; false = autre erreur serveur.
+  expired: boolean;
+};
+
+// Affiché à la place du dashboard quand les requêtes ES échouent. Auparavant un
+// échec (typiquement une API key expirée pendant la nuit) laissait la page en
+// spinner infini, sans aucune porte de sortie. Ce panneau donne une action
+// claire : effacer le cookie et revenir à l'écran de connexion.
+export function SessionExpiredCard({ expired }: Props) {
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
+
+  const reconnect = () => {
+    setIsLoggingOut(true);
+    fetch('/api/auth/invalidate-api-key', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({})
+    })
+      .catch(() => {})
+      .finally(() => {
+        window.location.href = '/';
+      });
+  };
+
+  return (
+    <Flex
+      flexDir="column"
+      alignItems="center"
+      justifyContent="center"
+      gap={4}
+      py={12}
+      px={6}
+      borderRadius={16}
+      bg="white"
+      w="full"
+      boxShadow="0px 8px 15px -4px rgba(36, 108, 249, 0.08), 0px 4px 6px -2px rgba(36, 108, 249, 0.08);"
+    >
+      <Text fontSize="3xl" role="img" aria-label="Session expirée">
+        🔒
+      </Text>
+      <Text textAlign="center" fontWeight={600} fontSize="lg">
+        {expired
+          ? 'Votre session a expiré'
+          : 'Une erreur est survenue lors du chargement des données'}
+      </Text>
+      <Text textAlign="center" color="gray.600">
+        {expired
+          ? 'Pour des raisons de sécurité, votre connexion a expiré. Veuillez vous reconnecter.'
+          : 'Merci de vous reconnecter. Si le problème persiste, contactez un administrateur.'}
+      </Text>
+      <Button
+        onClick={reconnect}
+        isLoading={isLoggingOut}
+        loadingText="Reconnexion..."
+        bg="primary.500"
+        color="white"
+        _hover={{ bg: 'primary.600' }}
+      >
+        Se reconnecter
+      </Button>
+    </Flex>
+  );
+}

--- a/webapp-next/middleware.ts
+++ b/webapp-next/middleware.ts
@@ -4,12 +4,9 @@ import { ELASTIC_API_KEY_NAME } from '@/utils/tools';
  
 export function middleware(request: NextRequest) {
 
-  // Ce middleware ne teste que la PRÉSENCE du cookie, pas la validité de l'API
-  // key ES (impossible sur le runtime edge : le client ES et le certificat CA
-  // ne sont pas disponibles ici). Ce test n'est fiable que parce que le cookie
-  // expire désormais en même temps que la key (Max-Age aligné sur `expiration:
-  // '1d'`, cf. setCookieServerSide). La validation réelle se fait côté API
-  // (401 → panneau "session expirée" + reconnexion), pas ici.
+  // Simple test de présence : le runtime edge ne peut pas valider la key ES.
+  // Fiable uniquement parce que le cookie expire avec la key (cf.
+  // setCookieServerSide) ; la vraie validation se fait côté API.
   const cookie = request.cookies.get(ELASTIC_API_KEY_NAME)?.value;
 
   if (request.nextUrl.pathname.startsWith('/bo')) {

--- a/webapp-next/middleware.ts
+++ b/webapp-next/middleware.ts
@@ -4,6 +4,12 @@ import { ELASTIC_API_KEY_NAME } from '@/utils/tools';
  
 export function middleware(request: NextRequest) {
 
+  // Ce middleware ne teste que la PRÉSENCE du cookie, pas la validité de l'API
+  // key ES (impossible sur le runtime edge : le client ES et le certificat CA
+  // ne sont pas disponibles ici). Ce test n'est fiable que parce que le cookie
+  // expire désormais en même temps que la key (Max-Age aligné sur `expiration:
+  // '1d'`, cf. setCookieServerSide). La validation réelle se fait côté API
+  // (401 → panneau "session expirée" + reconnexion), pas ici.
   const cookie = request.cookies.get(ELASTIC_API_KEY_NAME)?.value;
 
   if (request.nextUrl.pathname.startsWith('/bo')) {

--- a/webapp-next/pages/api/auth/invalidate-api-key.ts
+++ b/webapp-next/pages/api/auth/invalidate-api-key.ts
@@ -18,16 +18,12 @@ export default async function handler(
 
   const ca = fs.readFileSync(path.resolve(process.cwd(), "./certs/ca/ca.crt"));
 
-  // On efface le cookie DANS TOUS LES CAS, avant même de tenter l'invalidation
-  // ES. La déconnexion ne doit jamais dépendre du succès d'un appel ES : dans
-  // l'état "session expirée" l'ancien code (invalidation → 500 → cookie non
-  // effacé → reload → /bo → chargement infini) piégeait l'utilisateur.
+  // Effacé inconditionnellement : la déconnexion ne doit pas dépendre du succès
+  // de l'invalidation ES, sinon une session déjà expirée reste piégée.
   clearCookieServerSide(res);
 
-  // Récupère le username depuis la key du cookie plutôt que depuis le corps de
-  // requête : quand la session est expirée, le client ne connaît plus le
-  // username (l'appel /api/auth/user a lui aussi échoué). On garde le body en
-  // repli pour compat.
+  // username déduit de la key : en session expirée le client ne le connaît plus
+  // (/api/auth/user a échoué). Body en repli.
   const apiKey = req.cookies[ELASTIC_API_KEY_NAME];
   let username: string | undefined = req.body?.username;
 
@@ -40,10 +36,7 @@ export default async function handler(
       });
       const authenticated = await userClient.security.authenticate();
       username = authenticated.username;
-    } catch (e) {
-      // Key déjà expirée/invalide : rien à invalider côté ES, le cookie est
-      // effacé, la déconnexion est effective côté client.
-    }
+    } catch (e) {}
   }
 
   if (username) {
@@ -57,11 +50,8 @@ export default async function handler(
         tls: { ca, rejectUnauthorized: false }
       });
       await adminClient.security.invalidateApiKey({ username });
-    } catch (error) {
-      // Invalidation best-effort : l'échec ne doit pas bloquer la déconnexion.
-    }
+    } catch (error) {}
   }
 
-  // Toujours 200 : le cookie est effacé, le client peut retourner au login.
   res.status(200).json({ loggedOut: true });
 }

--- a/webapp-next/pages/api/auth/invalidate-api-key.ts
+++ b/webapp-next/pages/api/auth/invalidate-api-key.ts
@@ -1,4 +1,7 @@
-import { ELASTIC_API_KEY_NAME } from "@/utils/tools";
+import {
+  ELASTIC_API_KEY_NAME,
+  clearCookieServerSide
+} from "@/utils/tools";
 import { Client } from "@elastic/elasticsearch";
 import fs from "fs";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -8,38 +11,57 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  if (req.method === "POST") {
-    const { username } = req.body;
-
-    const adminClient = new Client({
-      node: process.env.ELASTIC_HOST,
-      auth: {
-        username: process.env.ELASTIC_USERNAME as string,
-        password: process.env.ELASTIC_PASSWORD as string,
-      },
-      tls: {
-        ca: fs.readFileSync(path.resolve(process.cwd(), "./certs/ca/ca.crt")),
-        rejectUnauthorized: false,
-      },
-    });
-
-    try {
-      const invalidatedApiKey = await adminClient.security.invalidateApiKey({
-        username,
-      });
-
-      res.setHeader("Set-Cookie", [
-        `${ELASTIC_API_KEY_NAME}=; Path=/; HttpOnly; Max-Age=-1; ${
-          process.env.NODE_ENV !== "development" ? "Secure" : ""
-        }`,
-      ]);
-
-      res.status(200).json(invalidatedApiKey);
-    } catch (error: any) {
-      res.status(500).end();
-    }
-  } else {
+  if (req.method !== "POST") {
     res.setHeader("Allow", "POST");
-    res.status(405).end("Method Not Allowed");
+    return res.status(405).end("Method Not Allowed");
   }
+
+  const ca = fs.readFileSync(path.resolve(process.cwd(), "./certs/ca/ca.crt"));
+
+  // On efface le cookie DANS TOUS LES CAS, avant même de tenter l'invalidation
+  // ES. La déconnexion ne doit jamais dépendre du succès d'un appel ES : dans
+  // l'état "session expirée" l'ancien code (invalidation → 500 → cookie non
+  // effacé → reload → /bo → chargement infini) piégeait l'utilisateur.
+  clearCookieServerSide(res);
+
+  // Récupère le username depuis la key du cookie plutôt que depuis le corps de
+  // requête : quand la session est expirée, le client ne connaît plus le
+  // username (l'appel /api/auth/user a lui aussi échoué). On garde le body en
+  // repli pour compat.
+  const apiKey = req.cookies[ELASTIC_API_KEY_NAME];
+  let username: string | undefined = req.body?.username;
+
+  if (apiKey) {
+    try {
+      const userClient = new Client({
+        node: process.env.ELASTIC_HOST,
+        auth: { apiKey },
+        tls: { ca, rejectUnauthorized: false }
+      });
+      const authenticated = await userClient.security.authenticate();
+      username = authenticated.username;
+    } catch (e) {
+      // Key déjà expirée/invalide : rien à invalider côté ES, le cookie est
+      // effacé, la déconnexion est effective côté client.
+    }
+  }
+
+  if (username) {
+    try {
+      const adminClient = new Client({
+        node: process.env.ELASTIC_HOST,
+        auth: {
+          username: process.env.ELASTIC_USERNAME as string,
+          password: process.env.ELASTIC_PASSWORD as string
+        },
+        tls: { ca, rejectUnauthorized: false }
+      });
+      await adminClient.security.invalidateApiKey({ username });
+    } catch (error) {
+      // Invalidation best-effort : l'échec ne doit pas bloquer la déconnexion.
+    }
+  }
+
+  // Toujours 200 : le cookie est effacé, le client peut retourner au login.
+  res.status(200).json({ loggedOut: true });
 }

--- a/webapp-next/pages/api/elk/data.ts
+++ b/webapp-next/pages/api/elk/data.ts
@@ -107,9 +107,8 @@ export default async function handler(
       .status(200)
       .json({ result: transformResult(result, aggregations, filters).body });
   } catch (error: any) {
-    // API key expirée / invalide → ES renvoie 401. On propage ce 401 tel quel
-    // pour que le client distingue "session expirée" d'une erreur serveur, au
-    // lieu d'un 500 non géré qui laissait la page en chargement infini.
+    // Propager le 401 ES (key expirée) tel quel : le client doit distinguer
+    // session expirée d'une vraie erreur serveur.
     const statusCode = error?.meta?.statusCode ?? error?.statusCode ?? 500;
     res
       .status(statusCode === 401 || statusCode === 403 ? 401 : 500)

--- a/webapp-next/pages/api/elk/data.ts
+++ b/webapp-next/pages/api/elk/data.ts
@@ -9,9 +9,11 @@ import fs from 'fs';
 import { NextApiRequest, NextApiResponse } from 'next';
 import path from 'path';
 
-type Data = {
-  result: SearchResponseBody<unknown, Record<string, AggregationsAggregate>>;
-};
+type Data =
+  | {
+      result: SearchResponseBody<unknown, Record<string, AggregationsAggregate>>;
+    }
+  | { error: string };
 
 // HANDLE ASSOCIATE CAUSES FILTER RESULT
 const transformResult = (
@@ -83,24 +85,34 @@ export default async function handler(
     : {};
   const index = (req.query.index as string) || 'cm2d_certificate'; // default to 'cm2d_certificate' if no index is provided
 
-  const result = await client.search(
-    {
-      index: index,
-      size: 100,
-      track_total_hits: true,
-      body: {
-        query: {
-          bool: {
-            filter: filters
-          }
-        },
-        aggs: aggregations
-      }
-    },
-    { meta: true }
-  );
+  try {
+    const result = await client.search(
+      {
+        index: index,
+        size: 100,
+        track_total_hits: true,
+        body: {
+          query: {
+            bool: {
+              filter: filters
+            }
+          },
+          aggs: aggregations
+        }
+      },
+      { meta: true }
+    );
 
-  res
-    .status(200)
-    .json({ result: transformResult(result, aggregations, filters).body });
+    res
+      .status(200)
+      .json({ result: transformResult(result, aggregations, filters).body });
+  } catch (error: any) {
+    // API key expirée / invalide → ES renvoie 401. On propage ce 401 tel quel
+    // pour que le client distingue "session expirée" d'une erreur serveur, au
+    // lieu d'un 500 non géré qui laissait la page en chargement infini.
+    const statusCode = error?.meta?.statusCode ?? error?.statusCode ?? 500;
+    res
+      .status(statusCode === 401 || statusCode === 403 ? 401 : 500)
+      .json({ error: statusCode === 401 || statusCode === 403 ? 'Unauthorized' : 'Internal Server Error' });
+  }
 }

--- a/webapp-next/pages/api/elk/first.ts
+++ b/webapp-next/pages/api/elk/first.ts
@@ -8,9 +8,11 @@ import {
 import { NextApiRequest, NextApiResponse } from 'next';
 import { ELASTIC_API_KEY_NAME } from '@/utils/tools';
 
-type Data = {
-  result: SearchResponseBody<unknown, Record<string, AggregationsAggregate>>;
-};
+type Data =
+  | {
+      result: SearchResponseBody<unknown, Record<string, AggregationsAggregate>>;
+    }
+  | { error: string };
 
 export default async function handler(
   req: NextApiRequest,
@@ -30,20 +32,29 @@ export default async function handler(
 
   const index = (req.query.index as string) || 'cm2d_certificate';
 
-  const result = await client.search(
-    {
-      index: index,
-      size: 1,
-      sort: [
-        {
-          date: {
-            order: 'asc'
+  try {
+    const result = await client.search(
+      {
+        index: index,
+        size: 1,
+        sort: [
+          {
+            date: {
+              order: 'asc'
+            }
           }
-        }
-      ]
-    },
-    { meta: true }
-  );
+        ]
+      },
+      { meta: true }
+    );
 
-  res.status(200).json({ result: result.body });
+    res.status(200).json({ result: result.body });
+  } catch (error: any) {
+    // Cf. api/elk/data.ts : key expirée → 401 propre au lieu d'un 500 non géré.
+    const statusCode = error?.meta?.statusCode ?? error?.statusCode ?? 500;
+    const is401 = statusCode === 401 || statusCode === 403;
+    res
+      .status(is401 ? 401 : 500)
+      .json({ error: is401 ? 'Unauthorized' : 'Internal Server Error' });
+  }
 }

--- a/webapp-next/pages/bo/index.tsx
+++ b/webapp-next/pages/bo/index.tsx
@@ -5,7 +5,8 @@ import MapIframe from '@/components/charts/map/Map';
 import { ChartTable } from '@/components/charts/table/Table';
 import { ClosableAlert } from '@/components/layouts/ClosableAlert';
 import { KPI } from '@/components/layouts/KPI';
-import { useData } from '@/utils/api';
+import { SessionExpiredCard } from '@/components/layouts/SessionExpiredCard';
+import { isSessionExpired, useData } from '@/utils/api';
 import { Cm2dContext } from '@/utils/cm2d-provider';
 import {
   addMissingSizes,
@@ -30,7 +31,10 @@ export default function Home() {
 
   const { filters, aggregations, view, setCSVData, dateInterval } = context;
 
-  const { data, dataKind, isLoading } = useData(filters, aggregations);
+  const { data, dataKind, isLoading, isError, isErrorKind } = useData(
+    filters,
+    aggregations
+  );
 
   const fetchNewTitle = async () => {
     if (!filters.categories[0]) setTitle('Nombre de certificats de décès');
@@ -87,6 +91,17 @@ export default function Home() {
       );
     }
   }, [data, view, dateInterval]);
+
+  // Erreur AVANT le chargement : sur échec, `data` reste undefined donc le test
+  // de chargement `|| !data` serait vrai à l'infini (spinner sans issue). On
+  // bascule sur un panneau d'erreur (session expirée le plus souvent : API key
+  // périmée pendant la nuit) offrant une reconnexion.
+  if (isError || isErrorKind)
+    return (
+      <SessionExpiredCard
+        expired={isSessionExpired(isError) || isSessionExpired(isErrorKind)}
+      />
+    );
 
   if (isLoading || !dataKind || !data)
     return (

--- a/webapp-next/pages/bo/index.tsx
+++ b/webapp-next/pages/bo/index.tsx
@@ -92,10 +92,8 @@ export default function Home() {
     }
   }, [data, view, dateInterval]);
 
-  // Erreur AVANT le chargement : sur échec, `data` reste undefined donc le test
-  // de chargement `|| !data` serait vrai à l'infini (spinner sans issue). On
-  // bascule sur un panneau d'erreur (session expirée le plus souvent : API key
-  // périmée pendant la nuit) offrant une reconnexion.
+  // Doit passer AVANT le test de chargement : sur erreur `data` reste undefined,
+  // donc `|| !data` resterait vrai indéfiniment (spinner sans issue).
   if (isError || isErrorKind)
     return (
       <SessionExpiredCard

--- a/webapp-next/scripts/seed-elastic.ts
+++ b/webapp-next/scripts/seed-elastic.ts
@@ -1,10 +1,5 @@
 /**
- * Injection de données de test dans l'index `cm2d_certificate` via l'API _bulk.
- *
- * Génère des certificats de décès synthétiques (mêmes listes de valeurs que
- * faker/main.py) couvrant TOUS les départements — métropole, Corse (2A/2B) et
- * DROM (971…976) — afin que la carte et la stratification par région soient
- * peuplées partout.
+ * Insère en masse des certificats de décès synthétiques dans `cm2d_certificate`.
  *
  * Usage :
  *   yarn seed:elastic                 # 1 000 000 documents (défaut)
@@ -13,12 +8,8 @@
  *
  * Prérequis : `yarn setup:elastic` (l'index et son mapping doivent exister).
  *
- * Différences volontaires avec faker/main.py :
- *  - Les catégories sont indexées en TABLEAUX (un token par cause) et non en
- *    chaîne "a; b; c". L'app filtre via `terms`/`match` exacts sur ces keyword ;
- *    seuls des tableaux font correspondre chaque cause individuellement.
- *  - Ajout de `@timestamp` (dérivé de `date`), requis par les transforms continus.
- *  - Départements tirés de REGIONS (source unique), DROM inclus.
+ * Les catégories sont indexées en TABLEAUX (un token par cause), non en chaîne
+ * "a; b; c" — l'app filtre via `terms`/`match` exacts sur ces keyword.
  */
 import { Client } from '@elastic/elasticsearch';
 import dotenv from 'dotenv';
@@ -47,19 +38,11 @@ const client = new Client({
   tls: { rejectUnauthorized: false },
 });
 
-// --- Listes de valeurs (portées depuis faker/main.py) ----------------------
-
-// Tous les codes département (métropole + Corse + DROM), dédupliqués depuis la
-// source unique des régions. Couvre l'intégralité de la carte.
 const DEPARTMENTS: string[] = Array.from(
   new Set(REGIONS.flatMap((r) => r.value))
 );
 
-// Populations approximatives (milliers d'habitants) par département. Sert de
-// poids au tirage : les volumes de décès simulés varient donc de façon
-// réaliste (Paris/Nord/Rhône élevés, Lozère/Creuse faibles), ce qui donne une
-// carte contrastée avec la colorimétrie ancrée sur la médiane. Valeurs
-// approximatives (données de test), non des chiffres officiels.
+// Poids du tirage : populations approximatives (données de test, non officielles).
 const DEPARTMENT_POPULATION: { [code: string]: number } = {
   '01': 657, '02': 526, '03': 335, '04': 165, '05': 141, '06': 1094,
   '07': 328, '08': 268, '09': 153, '10': 310, '11': 375, '12': 279,
@@ -80,7 +63,6 @@ const DEPARTMENT_POPULATION: { [code: string]: number } = {
   '971': 384, '972': 361, '973': 282, '974': 861, '976': 279,
 };
 
-// Tirage pondéré par population : table cumulée + recherche binaire.
 const DEPT_WEIGHTS = DEPARTMENTS.map((d) => DEPARTMENT_POPULATION[d] ?? 1);
 const DEPT_CUMULATIVE: number[] = [];
 let cumulativeWeight = 0;
@@ -177,14 +159,11 @@ const DEATH_LOCATIONS = [
 const SEXES = ['homme', 'femme', 'indéterminé'];
 const KINDS = ['Electronique', 'Papier'];
 
-// --- Générateurs -----------------------------------------------------------
-
 const pick = <T>(arr: T[]): T => arr[Math.floor(Math.random() * arr.length)];
 const randInt = (min: number, max: number): number =>
   Math.floor(Math.random() * (max - min + 1)) + min;
 
-// Reprend get_multiple_values : 20 % une seule valeur, sinon 2 à 5 valeurs
-// distinctes. Renvoie un TABLEAU (indexé tel quel dans un champ keyword).
+// Renvoie un TABLEAU (indexé tel quel dans un champ keyword).
 function multiValues(arr: string[]): string[] {
   if (Math.random() < 0.2) return [pick(arr)];
   const n = Math.min(randInt(2, 5), arr.length);
@@ -197,8 +176,7 @@ function multiValues(arr: string[]): string[] {
 }
 
 const START = new Date('2021-01-01').getTime();
-// Borne haute EXCLUSIVE : Math.random() ne l'atteint jamais, donc 2026-01-01
-// permet de couvrir jusqu'au 2025-12-31 inclus.
+// Borne haute EXCLUSIVE : 2026-01-01 couvre jusqu'au 2025-12-31 inclus.
 const END = new Date('2026-01-01').getTime();
 
 function makeDoc() {
@@ -206,12 +184,8 @@ function makeDoc() {
   const day = new Date(t);
   const date = day.toISOString().slice(0, 10); // YYYY-MM-DD (format iso8601)
   return {
-    // @timestamp = instant d'indexation (et NON la date de décès). Les
-    // transforms continus sont démarrés par setup:elastic sur un index vide :
-    // leur filigrane temporel est déjà ~maintenant. Un @timestamp dans le passé
-    // passerait sous ce filigrane et ne serait jamais traité ; l'instant présent
-    // (postérieur au démarrage) est détecté au checkpoint suivant. L'app ne lit
-    // jamais @timestamp, seul son rôle de champ de synchro compte.
+    // @timestamp doit être ~maintenant (pas la date de décès) : un timestamp
+    // passé tombe sous le filigrane des transforms continus et n'est jamais traité.
     '@timestamp': new Date().toISOString(),
     date,
     age: randInt(0, 100),
@@ -227,8 +201,6 @@ function makeDoc() {
     coordinates: `${(Math.random() * 180 - 90).toFixed(6)}, ${(Math.random() * 360 - 180).toFixed(6)}`,
   };
 }
-
-// --- Main ------------------------------------------------------------------
 
 async function main() {
   console.log(`CM2D — seed de ${COUNT} certificats dans ${INDEX}`);

--- a/webapp-next/scripts/setup-elastic.ts
+++ b/webapp-next/scripts/setup-elastic.ts
@@ -1,22 +1,13 @@
 /**
- * Initialisation automatique de l'environnement Elasticsearch CM2D.
- *
- * Provisionne, de façon idempotente, tout ce que le README décrivait
- * manuellement (Dev Tools + interface Kibana) :
- *   1. Index `cm2d_certificate` (mapping de référence, department = keyword)
- *   2. Index `cm2d_users`
- *   3. Les 19 rôles de région (source : utils/regions.ts)
- *   4. Les 5 transforms continus (créés puis démarrés)
- *   5. Le mot de passe de l'utilisateur `kibana_system`
- *   6. La copie du certificat ca.crt vers webapp-next/certs/ca (best-effort)
+ * Provisionne, de façon idempotente, l'environnement Elasticsearch CM2D :
+ * index (cm2d_certificate, cm2d_users), rôles de région, transforms continus,
+ * mot de passe kibana_system, copie de ca.crt.
  *
  * Usage :
  *   yarn setup:elastic            # crée ce qui manque, laisse l'existant
  *   yarn setup:elastic --reset    # SUPPRIME puis recrée tout (données incluses)
  *
- * Connexion : ELASTIC_HOST / ELASTIC_USERNAME / ELASTIC_PASSWORD (+ KIBANA_PASSWORD)
- * lus depuis webapp-next/.env puis ../.env. TLS auto-signé accepté
- * (rejectUnauthorized: false), aucun certificat requis pour ce script.
+ * Connexion via ELASTIC_HOST / ELASTIC_USERNAME / ELASTIC_PASSWORD (+ KIBANA_PASSWORD).
  */
 import { Client } from '@elastic/elasticsearch';
 import { execSync } from 'child_process';
@@ -25,11 +16,7 @@ import fs from 'fs';
 import path from 'path';
 import { ALL_REGION_ROLES } from '../utils/regions';
 
-// --- Configuration ---------------------------------------------------------
-
-// Charge d'abord le .env de la webapp (source des ELASTIC_*), puis celui de la
-// racine (source de KIBANA_PASSWORD). dotenv n'écrase pas les variables déjà
-// définies : le premier fichier chargé a donc la priorité.
+// dotenv n'écrase pas les vars déjà définies : le premier .env chargé gagne.
 dotenv.config({ path: path.resolve(process.cwd(), '.env') });
 dotenv.config({ path: path.resolve(process.cwd(), '../.env') });
 
@@ -44,10 +31,7 @@ const RESET = process.argv.includes('--reset');
 const CERTIFICATE_INDEX = 'cm2d_certificate';
 const USERS_INDEX = 'cm2d_users';
 
-// Utilisateur de test (DEV/LOCAL uniquement) pour se connecter à l'application.
-// username == email : requis par pages/api/auth/user.ts qui indexe les rôles
-// par email. Rôles : `viewer` (lecture des index cm2d_*) + `region-france-entiere`
-// (accès national/toutes régions dans l'UI).
+// DEV/LOCAL uniquement. username == email : requis par pages/api/auth/user.ts.
 const TEST_USER = 'user@test.loc';
 const TEST_PASSWORD = 'user123';
 const TEST_USER_ROLES = ['viewer', 'region-france-entiere'];
@@ -58,11 +42,8 @@ const client = new Client({
   tls: { rejectUnauthorized: false },
 });
 
-// --- Définitions -----------------------------------------------------------
-
-// Mapping de référence pour cm2d_certificate. `department` / `home_department`
-// sont des `keyword` (codes non numériques : DROM "971", Corse "2A"/"2B",
-// zéro initial "02"). `@timestamp` est requis par les transforms continus.
+// `department` / `home_department` en `keyword` : codes non numériques (971,
+// 2A, 02). `@timestamp` requis par les transforms continus.
 const CERTIFICATE_MAPPING = {
   _meta: { created_by: 'cm2d-setup-script' },
   properties: {
@@ -89,8 +70,6 @@ const USERS_MAPPING = {
   },
 } as const;
 
-// Les 5 transforms continus décrits dans le README.
-// `pivot` : agrégation par catégorie. `latest` : dernière valeur par clé.
 const SYNC = { time: { field: '@timestamp', delay: '60s' } };
 
 type TransformDef = {
@@ -137,8 +116,6 @@ const TRANSFORMS: TransformDef[] = [
   latestBy('cm2d_departments', 'Available departments', 'department'),
 ];
 
-// --- Utilitaires -----------------------------------------------------------
-
 const log = (msg: string) => console.log(msg);
 const ok = (msg: string) => console.log(`  ✓ ${msg}`);
 const skip = (msg: string) => console.log(`  – ${msg} (existe déjà)`);
@@ -182,13 +159,9 @@ async function transformExists(id: string): Promise<boolean> {
   }
 }
 
-// --- Étapes ----------------------------------------------------------------
-
 async function reset() {
   log('\n[--reset] Suppression des ressources existantes…');
 
-  // Transforms : arrêter (force) puis supprimer. Leurs index de destination
-  // aussi, pour repartir d'un état propre.
   for (const t of TRANSFORMS) {
     try {
       await client.transform.stopTransform({
@@ -271,8 +244,6 @@ async function setupRoles() {
 async function setupTestUser() {
   log('\nUtilisateur de test (dev/local)…');
   const existed = await userExists(TEST_USER);
-  // putUser fait un upsert : on garantit ainsi que les identifiants documentés
-  // restent valides à chaque exécution.
   await client.security.putUser({
     username: TEST_USER,
     password: TEST_PASSWORD,
@@ -295,7 +266,7 @@ async function setupTransforms() {
       await client.transform.putTransform({ transform_id: t.id, ...(t.body as any) });
       ok(`transform créé : ${t.id}`);
     }
-    // Démarrage (idempotent : on ignore l'erreur "déjà démarré").
+    // idempotent : on ignore l'erreur "déjà démarré".
     try {
       await client.transform.startTransform({ transform_id: t.id });
       ok(`transform démarré : ${t.id}`);
@@ -340,8 +311,6 @@ function copyCaCert() {
     console.warn(`      sudo ${cmd}`);
   }
 }
-
-// --- Main ------------------------------------------------------------------
 
 async function main() {
   log(`CM2D — initialisation Elasticsearch\n  hôte : ${ELASTIC_HOST}  (user: ${ELASTIC_USERNAME})`);

--- a/webapp-next/utils/api.ts
+++ b/webapp-next/utils/api.ts
@@ -3,6 +3,33 @@ import useSWR from 'swr';
 import { Filters } from './cm2d-provider';
 import { transformFilters } from './tools';
 
+// Erreur portant le code HTTP, pour que les composants distinguent une session
+// expirée (401) d'une autre erreur.
+export class FetchError extends Error {
+  status: number;
+  constructor(status: number, message?: string) {
+    super(message || `Request failed with status ${status}`);
+    this.name = 'FetchError';
+    this.status = status;
+  }
+}
+
+export function isSessionExpired(error: unknown): boolean {
+  return error instanceof FetchError && (error.status === 401 || error.status === 403);
+}
+
+// Fetcher partagé : vérifie res.ok AVANT de parser. Auparavant chaque hook
+// faisait `res.json()` sans contrôle → sur un 401/500 le parse échouait (ou
+// renvoyait un corps d'erreur pris pour de la donnée) et SWR ne remontait pas
+// d'erreur exploitable → chargement infini.
+async function elkFetcher(input: RequestInfo, init?: RequestInit) {
+  const res = await fetch(input, init);
+  if (!res.ok) {
+    throw new FetchError(res.status);
+  }
+  return superJSONParse<any>(stringify(await res.json()));
+}
+
 export function useSexes() {
   const params = {
     index: 'cm2d_sexes'
@@ -10,10 +37,7 @@ export function useSexes() {
 
   const { data, error } = useSWR(
     `/api/elk/data?${new URLSearchParams(params)}`,
-    async function (input: RequestInfo, init?: RequestInit) {
-      const res = await fetch(input, init);
-      return superJSONParse<any>(stringify(await res.json()));
-    }
+    elkFetcher
   );
 
   return {
@@ -30,10 +54,7 @@ export function useDeathLocations() {
 
   const { data, error } = useSWR(
     `/api/elk/data?${new URLSearchParams(params)}`,
-    async function (input: RequestInfo, init?: RequestInit) {
-      const res = await fetch(input, init);
-      return superJSONParse<any>(stringify(await res.json()));
-    }
+    elkFetcher
   );
 
   return {
@@ -50,10 +71,7 @@ export function useCauses() {
 
   const { data, error } = useSWR(
     `/api/elk/data?${new URLSearchParams(params)}`,
-    async function (input: RequestInfo, init?: RequestInit) {
-      const res = await fetch(input, init);
-      return superJSONParse<any>(stringify(await res.json()));
-    }
+    elkFetcher
   );
 
   return {
@@ -70,10 +88,7 @@ export function useAssociateCauses() {
 
   const { data, error } = useSWR(
     `/api/elk/data?${new URLSearchParams(params)}`,
-    async function (input: RequestInfo, init?: RequestInit) {
-      const res = await fetch(input, init);
-      return superJSONParse<any>(stringify(await res.json()));
-    }
+    elkFetcher
   );
 
   return {
@@ -95,10 +110,7 @@ export function useDepartments(departments: string[]) {
 
   const { data, error } = useSWR(
     `/api/elk/data?${new URLSearchParams(params)}`,
-    async function (input: RequestInfo, init?: RequestInit) {
-      const res = await fetch(input, init);
-      return superJSONParse<any>(stringify(await res.json()));
-    }
+    elkFetcher
   );
 
   return {
@@ -117,10 +129,7 @@ export function useData(filters: Filters, aggregations: any) {
 
   const { data, error } = useSWR(
     `/api/elk/data?${new URLSearchParams(params)}`,
-    async function (input: RequestInfo, init?: RequestInit) {
-      const res = await fetch(input, init);
-      return superJSONParse<any>(stringify(await res.json()));
-    }
+    elkFetcher
   );
 
   const paramsKind = {
@@ -132,10 +141,7 @@ export function useData(filters: Filters, aggregations: any) {
   };
   const { data: dataKind, error: errorKind } = useSWR(
     `/api/elk/data?${new URLSearchParams(paramsKind)}`,
-    async function (input: RequestInfo, init?: RequestInit) {
-      const res = await fetch(input, init);
-      return superJSONParse<any>(stringify(await res.json()));
-    }
+    elkFetcher
   );
 
   return {

--- a/webapp-next/utils/api.ts
+++ b/webapp-next/utils/api.ts
@@ -3,8 +3,6 @@ import useSWR from 'swr';
 import { Filters } from './cm2d-provider';
 import { transformFilters } from './tools';
 
-// Erreur portant le code HTTP, pour que les composants distinguent une session
-// expirée (401) d'une autre erreur.
 export class FetchError extends Error {
   status: number;
   constructor(status: number, message?: string) {
@@ -18,12 +16,10 @@ export function isSessionExpired(error: unknown): boolean {
   return error instanceof FetchError && (error.status === 401 || error.status === 403);
 }
 
-// Fetcher partagé : vérifie res.ok AVANT de parser. Auparavant chaque hook
-// faisait `res.json()` sans contrôle → sur un 401/500 le parse échouait (ou
-// renvoyait un corps d'erreur pris pour de la donnée) et SWR ne remontait pas
-// d'erreur exploitable → chargement infini.
 async function elkFetcher(input: RequestInfo, init?: RequestInit) {
   const res = await fetch(input, init);
+  // Sans ce garde, un 401/500 finissait parsé comme donnée et SWR ne remontait
+  // aucune erreur → chargement infini côté /bo.
   if (!res.ok) {
     throw new FetchError(res.status);
   }

--- a/webapp-next/utils/cm2d-provider.tsx
+++ b/webapp-next/utils/cm2d-provider.tsx
@@ -25,6 +25,9 @@ export type Filters = {
   region_departments: string[];
   start_date?: string;
   end_date?: string;
+  // Comparaison courbe : année avec laquelle comparer la même période (mode
+  // exclusif de la stratification). undefined = désactivé.
+  compare_year?: number;
 };
 
 export type User = {

--- a/webapp-next/utils/cm2d-provider.tsx
+++ b/webapp-next/utils/cm2d-provider.tsx
@@ -101,28 +101,33 @@ export function Cm2dProvider({ children }: Cm2dProviderProps) {
   const [CSVData, setCSVData] = useState<string[][]>([]);
   const [user, setUser] = useState<User>({} as User);
 
+  // On teste res.ok avant de parser : un 401 (session expirée) renvoie du texte,
+  // et l'ancien `res.json()` inconditionnel levait une exception non gérée
+  // (rejet de promesse remonté à Sentry) au lieu d'un simple échec silencieux.
   const fetchFirstData = () => {
-    fetch('/api/elk/first', { method: 'GET' }).then(res =>
-      res.json().then(data => {
-        const date = data?.result?.hits?.hits[0]._source.date;
+    fetch('/api/elk/first', { method: 'GET' })
+      .then(res => (res.ok ? res.json() : null))
+      .then(data => {
+        const date = data?.result?.hits?.hits[0]?._source?.date;
         if (date) setFirstDate(new Date(date));
       })
-    );
+      .catch(() => {});
   };
 
   const fetchUser = () => {
-    fetch('/api/auth/user', { method: 'GET' }).then(res =>
-      res.json().then(user => {
+    fetch('/api/auth/user', { method: 'GET' })
+      .then(res => (res.ok ? res.json() : null))
+      .then(user => {
         if (user) {
           setUser({
             username: user.username,
             fullName: user.full_name,
             email: user.email,
-            roles: user.roles.filter((r: string) => r !== 'viewer')
+            roles: (user.roles || []).filter((r: string) => r !== 'viewer')
           });
         }
       })
-    );
+      .catch(() => {});
   };
 
   useEffect(() => {

--- a/webapp-next/utils/cm2d-provider.tsx
+++ b/webapp-next/utils/cm2d-provider.tsx
@@ -25,8 +25,8 @@ export type Filters = {
   region_departments: string[];
   start_date?: string;
   end_date?: string;
-  // Comparaison courbe : année avec laquelle comparer la même période (mode
-  // exclusif de la stratification). undefined = désactivé.
+  // Année de comparaison (même période, autre année). Exclusif de la
+  // stratification. undefined = désactivé.
   compare_year?: number;
 };
 
@@ -101,9 +101,6 @@ export function Cm2dProvider({ children }: Cm2dProviderProps) {
   const [CSVData, setCSVData] = useState<string[][]>([]);
   const [user, setUser] = useState<User>({} as User);
 
-  // On teste res.ok avant de parser : un 401 (session expirée) renvoie du texte,
-  // et l'ancien `res.json()` inconditionnel levait une exception non gérée
-  // (rejet de promesse remonté à Sentry) au lieu d'un simple échec silencieux.
   const fetchFirstData = () => {
     fetch('/api/elk/first', { method: 'GET' })
       .then(res => (res.ok ? res.json() : null))

--- a/webapp-next/utils/map/details.ts
+++ b/webapp-next/utils/map/details.ts
@@ -1,7 +1,4 @@
-// Extrait les couples { label, value } de la description HTML d'un département
-// (ex. `<div>Homme : 12</div>`), présents uniquement en mode stratifié.
-// Utilisé par l'infobulle de la carte (MapTooltip) pour afficher la ventilation
-// par valeur en mode stratifié.
+// Re-parse la description HTML produite par getMapProps (couplage à surveiller).
 export function extractDetailsValues(
   input: string
 ): { label: string; value: number }[] {

--- a/webapp-next/utils/map/props.ts
+++ b/webapp-next/utils/map/props.ts
@@ -64,8 +64,6 @@ export const getMapProps = (
     }
   };
 
-  // Total de décès d'un département (somme des enfants en mode stratifié, sinon
-  // doc_count). Sert à la fois à la colorimétrie et au calcul de la médiane.
   const getDeptTotal = (key: string): number => {
     const hit = hits.find(h => h.key === key);
     if (!hit) return 0;
@@ -80,8 +78,8 @@ export const getMapProps = (
 
   const getCountFromKey = (key: string): number => getDeptTotal(key);
 
-  // Médiane des décès sur les départements affichés AYANT des données (>0).
-  // Robuste aux outliers (ex. Paris) et non tirée vers le bas par les zéros.
+  // Médiane sur les départements >0 : robuste aux outliers (Paris), pas tirée
+  // vers le bas par les zéros.
   const sortedCounts = departments
     .map(getDeptTotal)
     .filter(c => c > 0)
@@ -93,8 +91,7 @@ export const getMapProps = (
       : (sortedCounts[n / 2 - 1] + sortedCounts[n / 2]) / 2
     : 0;
 
-  // Colorimétrie ancrée sur la médiane : vert bien en dessous, bleu autour,
-  // orange au dessus, rouge très au dessus. Sans données / médiane nulle → gris.
+  // Seuils relatifs à la médiane ; gris si pas de données.
   const getColorFromCount = (
     key: string,
     kind: 'initial' | 'hover'
@@ -140,9 +137,7 @@ export const getMapProps = (
     return `Nombre de décès : ${getCountFromKey(key)}`;
   };
 
-  // state_specific est désormais indexé par CODE DÉPARTEMENT (ex "75", "971"),
-  // ce qui correspond à la propriété `code` des features GeoJSON rendues par
-  // react-simple-maps (métropole + DROM), et alimente aussi l'infobulle (MapTooltip).
+  // Indexé par code département (cf. contrat sur MapConfig.state_specific).
   const states: MapConfig['state_specific'] = {};
   departments.forEach(d => {
     states[d] = {

--- a/webapp-next/utils/map/type.ts
+++ b/webapp-next/utils/map/type.ts
@@ -1,6 +1,5 @@
 export type MapConfig = {
-  // Détail par département (clé = code département), consommé par la carte
-  // (react-simple-maps) et l'infobulle de survol (MapTooltip).
+  // Clé = code département (doit matcher la propriété `code` du GeoJSON).
   state_specific: {
     [key: string]: {
       name: string;

--- a/webapp-next/utils/regions.ts
+++ b/webapp-next/utils/regions.ts
@@ -1,16 +1,9 @@
-// Source unique des régions et de leurs rôles ES associés.
-//
-// Importé à la fois par l'application (via tools.ts) et par le script
-// d'initialisation Elasticsearch (scripts/setup-elastic.ts). Ce module ne doit
-// AUCUNE dépendance React/Next/date-fns afin de rester importable depuis un
-// script Node autonome, et pour que la liste des rôles provisionnés dans
-// Elasticsearch ne dérive jamais de celle utilisée par l'app.
+// Source unique des régions/rôles, importée aussi par scripts/setup-elastic.ts.
+// Ne doit AUCUNE dépendance React/Next : doit rester importable depuis un script
+// Node autonome.
 
 export type Region = { label: string; role: string; value: string[] };
 
-// Régions métropolitaines et d'outre-mer : label, rôle ES associé, et liste des
-// départements. Source unique partagée par le sélecteur de région
-// (Regions.tsx) et la stratification "par région" des graphes.
 export const REGIONS: Region[] = [
   {
     label: "Ile-de-France",
@@ -75,7 +68,6 @@ export const REGIONS: Region[] = [
     role: "region-provence-alpes-cote-dazur",
     value: ["04", "05", "06", "13", "83", "84"],
   },
-  // Régions d'outre-mer (ROM) : chacune monodépartementale.
   { label: "Guadeloupe", role: "region-guadeloupe", value: ["971"] },
   { label: "Martinique", role: "region-martinique", value: ["972"] },
   { label: "Guyane", role: "region-guyane", value: ["973"] },
@@ -83,11 +75,8 @@ export const REGIONS: Region[] = [
   { label: "Mayotte", role: "region-mayotte", value: ["976"] },
 ];
 
-// Rôle spécial "France entière" (utilisé côté UI dans Regions.tsx) : accès
-// national, sans filtrage par région. Aucun département associé.
 export const FRANCE_ENTIERE_ROLE = "region-france-entiere";
 
-// Ensemble des rôles ES à provisionner : "France entière" + un rôle par région.
 export const ALL_REGION_ROLES: string[] = [
   FRANCE_ENTIERE_ROLE,
   ...REGIONS.map((r) => r.role),

--- a/webapp-next/utils/tools.ts
+++ b/webapp-next/utils/tools.ts
@@ -4,9 +4,6 @@ import { DateInterval, Filters, SearchCategory, View } from './cm2d-provider';
 import { NextApiResponse } from 'next';
 import { REGIONS } from './regions';
 
-// Ré-export : la source unique des régions vit désormais dans ./regions
-// (module sans dépendance React), afin d'être partagée avec le script
-// d'initialisation Elasticsearch sans dérive.
 export { REGIONS, FRANCE_ENTIERE_ROLE, ALL_REGION_ROLES } from './regions';
 export type { Region } from './regions';
 
@@ -221,26 +218,18 @@ export const departmentsCodes: { [key: string]: string } = {
   "78": "FRA5357", // Yvelines
 };
 
-// Tous les départements (métropole + DROM) — utilisé par l'option "France
-// entière" (rôle region-france-entiere) pour lever le filtrage par région.
-// Basé sur departmentRefs (et non departmentsCodes, limité à la carte
-// métropolitaine) afin d'inclure les DROM dans les données et les filtres.
+// departmentRefs (et non departmentsCodes, limité à la métropole) pour inclure
+// les DROM.
 export const ALL_DEPARTMENTS: string[] = Object.keys(departmentRefs);
 
-// DROM (départements et régions d'outre-mer).
 export const DROM_DEPARTMENTS: string[] = ["971", "972", "973", "974", "976"];
 
-// France hexagonale : métropole (Corse incluse) sans les DROM — utilisé par
-// l'option "France hexagonale", réservée au rôle region-france-entiere.
 export const HEXAGON_DEPARTMENTS: string[] = ALL_DEPARTMENTS.filter(
   (d) => !DROM_DEPARTMENTS.includes(d)
 );
-// Agrégation ES "par région" : un bucket nommé par région, chacun filtrant sur
-// les home_department de la région. On NE passe PAS `keyed` : le paramètre n'est
-// supporté par l'agg `filters` qu'à partir d'Elasticsearch 7.11 et l'instance
-// de prod le rejette ("Unknown key for a VALUE_BOOLEAN in [...]: [keyed]").
-// Sans `keyed`, les buckets sont renvoyés sous forme d'objet { label: bucket } ;
-// `normalizeBuckets` les remet en tableau côté lecture.
+// Pas de `keyed` : non supporté par l'agg `filters` avant Elasticsearch 7.11,
+// rejeté par l'instance de prod ("Unknown key for a VALUE_BOOLEAN [...]: [keyed]").
+// Les buckets sont donc renvoyés en objet { label: bucket } → normalizeBuckets.
 export function buildRegionFiltersAgg() {
   const filters: { [label: string]: any } = {};
   REGIONS.forEach((r) => {
@@ -409,9 +398,8 @@ export function transformFilters(filters: Filters): any[] {
     };
 
     if (filters.compare_year) {
-      // Comparaison : on OR la période courante avec la même période décalée sur
-      // l'année choisie (mêmes mois/jours). La stratification par année (agg)
-      // sépare ensuite les deux années en deux courbes superposables.
+      // OR entre la période courante et la même période décalée sur l'année
+      // comparée ; la stratification par année sépare ensuite les deux courbes.
       const shiftedStart = new Date(filters.start_date);
       const shiftedEnd = new Date(filters.end_date);
       shiftedStart.setFullYear(filters.compare_year);
@@ -488,10 +476,9 @@ export function getCSVDataFromDatasets(
   return csvData;
 }
 
-// Une agg `filters` (stratification par région) renvoie ses buckets sous forme
-// d'objet { label: bucket } et non de tableau (on n'utilise pas `keyed`, cf.
-// buildRegionFiltersAgg). Les aggs terms/range/date_histogram renvoient déjà un
-// tableau. On normalise vers un tableau dont chaque bucket porte `key` = label.
+// L'agg `filters` sans `keyed` renvoie ses buckets en objet { label: bucket }
+// (cf. buildRegionFiltersAgg) ; on les ramène au tableau { key, ... } des autres
+// aggs.
 function normalizeBuckets(agg: any): any[] {
   if (!agg || !agg.buckets) return [];
   if (Array.isArray(agg.buckets)) return agg.buckets;
@@ -645,9 +632,6 @@ export function dateToWeekYear(inputDate: Date): string {
   return formattedString;
 }
 
-// Formate une date selon le pas de la vue courbe (semaine/jour/mois).
-// `withYear` : afficher l'année. Sur l'axe on ne l'affiche que si la période
-// couvre plusieurs années ; dans le CSV on la met toujours (fichier lisible seul).
 export function formatDateByInterval(
   date: Date,
   interval: DateInterval,
@@ -661,7 +645,6 @@ export function formatDateByInterval(
     return withYear ? `${dd}/${mm}/${date.getFullYear()}` : `${dd}/${mm}`;
   }
 
-  // month
   const monthLong = new Intl.DateTimeFormat("fr-FR", { month: "long" }).format(
     date
   );
@@ -906,14 +889,9 @@ export const ELASTIC_API_KEY_NAME =
   (process.env.NEXT_PUBLIC_ELASTIC_API_KEY_NAME as string) || 'cm2d_api_key';
 
 
-// Durée de vie du cookie alignée sur l'expiration de l'API key ES (grantApiKey
-// `expiration: '1d'`, cf. api/auth/index.ts). Sans Max-Age le cookie était un
-// cookie de session : il survivait à la key (expirée en 24h) — le lendemain
-// matin le cookie restait présent alors que la key était morte, ce qui piégeait
-// l'utilisateur (middleware = "connecté", mais toutes les requêtes ES en 401).
-// Cookie et key expirent désormais ensemble → le middleware, qui ne teste que la
-// présence du cookie, redevient fiable.
-const COOKIE_MAX_AGE_SECONDS = 24 * 60 * 60; // 1 jour, = expiration de la key
+// Doit rester aligné sur l'expiration de la key ES (grantApiKey `expiration:
+// '1d'`) : un cookie de session survivrait à la key et piégerait l'utilisateur.
+const COOKIE_MAX_AGE_SECONDS = 24 * 60 * 60;
 
 export const setCookieServerSide = (
   res: NextApiResponse,
@@ -927,9 +905,6 @@ export const setCookieServerSide = (
   );
 };
 
-// Efface le cookie d'API key côté client (déconnexion / session expirée).
-// Indépendant de toute invalidation ES : appelé systématiquement pour garantir
-// une sortie propre même si l'invalidation de la key échoue.
 export const clearCookieServerSide = (res: NextApiResponse) => {
   res.setHeader(
     "Set-Cookie",

--- a/webapp-next/utils/tools.ts
+++ b/webapp-next/utils/tools.ts
@@ -906,13 +906,34 @@ export const ELASTIC_API_KEY_NAME =
   (process.env.NEXT_PUBLIC_ELASTIC_API_KEY_NAME as string) || 'cm2d_api_key';
 
 
+// Durée de vie du cookie alignée sur l'expiration de l'API key ES (grantApiKey
+// `expiration: '1d'`, cf. api/auth/index.ts). Sans Max-Age le cookie était un
+// cookie de session : il survivait à la key (expirée en 24h) — le lendemain
+// matin le cookie restait présent alors que la key était morte, ce qui piégeait
+// l'utilisateur (middleware = "connecté", mais toutes les requêtes ES en 401).
+// Cookie et key expirent désormais ensemble → le middleware, qui ne teste que la
+// présence du cookie, redevient fiable.
+const COOKIE_MAX_AGE_SECONDS = 24 * 60 * 60; // 1 jour, = expiration de la key
+
 export const setCookieServerSide = (
   res: NextApiResponse,
   securityTokenEncoded: string
 ) => {
   res.setHeader(
     "Set-Cookie",
-    `${ELASTIC_API_KEY_NAME}=${securityTokenEncoded}; path=/; HttpOnly; ${
+    `${ELASTIC_API_KEY_NAME}=${securityTokenEncoded}; Path=/; HttpOnly; SameSite=Lax; Max-Age=${COOKIE_MAX_AGE_SECONDS}; ${
+      process.env.NODE_ENV !== "development" ? "Secure;" : ""
+    }`
+  );
+};
+
+// Efface le cookie d'API key côté client (déconnexion / session expirée).
+// Indépendant de toute invalidation ES : appelé systématiquement pour garantir
+// une sortie propre même si l'invalidation de la key échoue.
+export const clearCookieServerSide = (res: NextApiResponse) => {
+  res.setHeader(
+    "Set-Cookie",
+    `${ELASTIC_API_KEY_NAME}=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0; ${
       process.env.NODE_ENV !== "development" ? "Secure;" : ""
     }`
   );

--- a/webapp-next/utils/tools.ts
+++ b/webapp-next/utils/tools.ts
@@ -404,14 +404,38 @@ export function transformFilters(filters: Filters): any[] {
   });
 
   if (filters.start_date && filters.end_date) {
-    transformed.push({
-      range: {
-        date: {
-          gte: filters.start_date,
-          lte: filters.end_date,
+    const baseRange = {
+      range: { date: { gte: filters.start_date, lte: filters.end_date } },
+    };
+
+    if (filters.compare_year) {
+      // Comparaison : on OR la période courante avec la même période décalée sur
+      // l'année choisie (mêmes mois/jours). La stratification par année (agg)
+      // sépare ensuite les deux années en deux courbes superposables.
+      const shiftedStart = new Date(filters.start_date);
+      const shiftedEnd = new Date(filters.end_date);
+      shiftedStart.setFullYear(filters.compare_year);
+      shiftedEnd.setFullYear(filters.compare_year);
+
+      transformed.push({
+        bool: {
+          should: [
+            baseRange,
+            {
+              range: {
+                date: {
+                  gte: shiftedStart.toISOString(),
+                  lte: shiftedEnd.toISOString(),
+                },
+              },
+            },
+          ],
+          minimum_should_match: 1,
         },
-      },
-    });
+      });
+    } else {
+      transformed.push(baseRange);
+    }
   }
 
   return transformed;


### PR DESCRIPTION
## Objectif

Ajouter, sur la vue **courbe**, une option pour **comparer la même période sur une année précédente** (ex. janv–juil 2025 vs janv–juil 2024). C'est une feature distincte de la distribution stratifiée par année : au lieu de redécouper les données courantes, on va **chercher en plus** la même période d'une autre année et on la superpose.

## Comportement

- Un menu **« Comparaison »** apparaît sur la courbe **uniquement quand la période tient sur une seule année**.
- On y choisit une année à comparer : de l'année précédant la période jusqu'à la première date disponible (`firstDate`).
- Les deux années sont tracées **superposées** sur un axe commun mois/semaine/jour (réutilise l'axe normalisé de la stratification par année).
- Mode **exclusif** de la distribution stratifiée : activer l'un désactive l'autre.

## Implémentation

- `filters.compare_year?: number` (nouveau champ).
- `transformFilters` : quand `compare_year` est défini, le filtre date devient un `bool.should` de deux plages — la période courante et la même période décalée sur l'année choisie — au lieu d'une seule plage.
- `line/Header.tsx` : nouveau menu, gestion de l'exclusivité, et bascule de l'agrégation en `date_histogram(année) → granularité` en mode comparaison.
- `line/Line.tsx` : l'axe normalisé (superposition par mois/semaine/jour) se déclenche aussi en mode comparaison.

## Test

1. Vue courbe, période sur une seule année (ex. 2025).
2. Menu « Comparaison » → choisir une année (ex. 2024).
3. Deux courbes superposées sur le même axe, comparables. Tester les granularités mois / semaine / jour.

## Limite connue

Si on étend la période à plusieurs années alors qu'une comparaison est active, le menu se masque mais `compare_year` reste posé jusqu'à repasser sur une période mono-année ou changer de mode. À raffiner si gênant.

## Vérification

Type-check projet complet OK. Validation visuelle en navigateur à faire au review.
